### PR TITLE
Read entire binary file instead of just first 8 instructions

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -7,7 +7,7 @@ LD  = gcc-4.8
 EXE =
 O = .o
 
-../obj/%$(O) : %.cpp
+../obj/%$(O) : %.cpp ../obj
 	$(CC) $(FLAGS) $(CPPFLAGS) -o $@ $<
 
 BASEOBJECTS = ../obj/utils$(O) ../obj/expr$(O) ../obj/Inst$(O) ../obj/Eval$(O) ../obj/Validator$(O)
@@ -18,6 +18,9 @@ all: ../bin/vc4asm$(EXE) ../bin/vc4dis$(EXE)
 
 clean:
 	-rm ../bin/* ../obj/*
+
+../obj :
+	mkdir ../obj
 
 ../bin/vc4asm$(EXE) : $(ASMOBJECTS)
 	$(LD) $(FLAGS) $(LDFLAGS) -o $@ $(ASMOBJECTS) $(LIBS)


### PR DESCRIPTION
`vc4dis` wasn't reading the entire binary file so this PR fixes it. Since it is a C++ file I also switched to C++ style I/O which make it much shorter as a bonus. Also I make the obj directory which does not exist in a fresh clone/download
