### PR TITLE
Fixed some compile errors on my 64bit Ubuntu.

### DIFF
--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -1546,7 +1546,7 @@ void Parser::endREP(int mode)
 	else
 		sscanf(m.Args[1].c_str(), "%zi", &count);
 	auto& current = *Context.back();
-	auto& value = current.Consts.emplace(m.Args.front(), constDef(exprValue(0LL), current)).first->second.Value;
+	auto& value = current.Consts.emplace(m.Args.front(), constDef(exprValue((int64_t)0), current)).first->second.Value;
 	for (size_t i = 0; i < count; ++i)
 	{	// set argument
 		if (mode)
@@ -1630,7 +1630,7 @@ void Parser::parseCLONE(int)
 
 	FlagsSize(PC + (unsigned)param2.iValue);
 	param2.iValue += param1.iValue; // end offset rather than count
-	if (Pass2 && param2.iValue >= Instructions.size())
+	if (Pass2 && (unsigned)param2.iValue >= Instructions.size())
 		Fail("Cannot clone behind the end of the code.");
 
 	if (doALIGN(64))

--- a/src/vc4dis.cpp
+++ b/src/vc4dis.cpp
@@ -1,6 +1,7 @@
 #include "Disassembler.h"
 #include "Validator.h"
 
+#include <cinttypes>
 #include <stdio.h>
 #include <stdlib.h>
 #include <errno.h>
@@ -66,8 +67,8 @@ static void file_load_x32(const char *filename, vector<uint64_t>& memory)
 		return;
 	}
 	uint32_t value1, value2;
-	while ((fscanf(f, "%*[ \t]"), fscanf(f, "//%*[^\n]"), fscanf(f, "%x,", &value1)) == 1)
-	{	if (fscanf(f, "%x,", &value2) != 1)
+	while ((fscanf(f, "%*[ \t]"), fscanf(f, "//%*[^\n]"), fscanf(f, "%" SCNx32 ",", &value1)) == 1)
+	{	if (fscanf(f, "%" SCNx32 "x,", &value2) != 1)
 		{	if (feof(f))
 			{	fprintf(stderr, "File %s must contain an even number of 32 bit words.\n", filename);
 				goto done;
@@ -94,7 +95,7 @@ static void file_load_x64(const char *filename, vector<uint64_t>& memory)
 		return;
 	}
 	uint64_t value;
-	while ((fscanf(f, "%*[ \t]"), fscanf(f, "//%*[^\n]"), fscanf(f, "%Lx,", &value)) == 1)
+	while ((fscanf(f, "%*[ \t]"), fscanf(f, "//%*[^\n]"), fscanf(f, "%" SCNx64 ",", &value)) == 1)
 		memory.push_back(value);
 	if (!feof(f))
 	{	char buf[10];


### PR DESCRIPTION
- It was assumed `long long` == `int64_t`.
- It was assumed `%Lx` was a suitable argument to `scanf` for `uint64_t`.
- It was assumed `%x` was a suitable argument to `scanf` for `uint32_t`.
- Fixed warning with unsigned/signed comparison. This warrants further investigation to prove its safe, which I haven't done.
