### PR TITLE
Add documentation for 32s pack mode

### DIFF
--- a/doc/extensions.html
+++ b/doc/extensions.html
@@ -137,7 +137,7 @@
           <td><tt>int32</tt></td>
           <td><tt>int32</tt></td>
           <td><nobr><tt>3 2 1 0</tt></nobr></td>
-          <td><i>unknown</i></td>
+          <td><tt>0x7fffffff</tt> if signed overflow/underflow, otherwise <tt>x</tt></td>
           <td><var></var>reg A</td>
           <td class="inactive" style="text-align: center;" colspan="2" rowspan="1">n/a<br>
           </td>


### PR DESCRIPTION
In `32s` pack mode, if the operation results in signed overflow/underflow the result is set to `0x7fffffff`, otherwise it is left as is.  I tested this with both underflow and overflow of various quantities and saw consistent results.  Note that this is distinct from the carry flag, which is set on unsigned overflow/underflow.