### PR TITLE
Add callback to Validator

### DIFF
--- a/src/Validator.cpp
+++ b/src/Validator.cpp
@@ -32,23 +32,36 @@ Validator::state::state(const state& r, int at, int target)
 }
 
 
-void Validator::Message(int refloc, const char* fmt, ...)
+void Validator::Message(FailureType type, int refloc, const char* fmt, ...)
 {	if (refloc < Start)
 		refloc += From - Start;
 	else if (Pass2 && refloc >= Start)
 		return; // Discard message because of second pass.
 	va_list va;
 	va_start(va, fmt);
+	char buffer[1024];
 	fputs("Warning: ", stderr);
+	strcpy(buffer, "Warning: ");
+	int bufPos = strlen("Warning: ");
 	vfprintf(stderr, fmt, va);
+	bufPos += vsprintf(buffer + bufPos, fmt, va);
 	va_end(va);
 	fprintf(stderr, "\n  instruction at 0x%x", BaseAddr + At * (unsigned)sizeof(uint64_t));
+	bufPos += sprintf(buffer + bufPos, "\n  instruction at 0x%x", BaseAddr + At * (unsigned)sizeof(uint64_t));
 	if (refloc >= 0 && refloc != At)
+	{
 		fprintf(stderr, " referring to instruction at 0x%x", BaseAddr + refloc * (unsigned)sizeof(uint64_t));
+		bufPos += sprintf(buffer + bufPos, " referring to instruction at 0x%x", BaseAddr + refloc * (unsigned)sizeof(uint64_t));
+	}
 	fputc('\n', stderr);
 	if (Info)
 	{	auto loc = Info->LineNumbers[At];
 		fprintf(stderr, "  generated at %s (%u)\n", Info->SourceFiles[loc.File].Name.c_str(), loc.Line);
+		bufPos += sprintf(buffer + bufPos, ",  generated at %s (%u)\n", Info->SourceFiles[loc.File].Name.c_str(), loc.Line);
+	}
+	if(callback != nullptr)
+	{
+		callback(type, refloc, buffer);
 	}
 }
 
@@ -108,7 +121,7 @@ void Validator::CheckRotSrc(const state& st, Inst::mux mux)
 	// detailed check on current instruction
 	if (CheckVectorRotationLevel > 1 || Instruct.isSFMUL())
 	{warn:
-		Message(At-1, "Should not write to the source r%u of the vector rotation in the previous instruction.", mux);
+		Message(FailureType::VECTOR_ROTATION_WRITE_SOURCE, At-1, "Should not write to the source r%u of the vector rotation in the previous instruction.", mux);
 		return;
 	}
 	if (Instruct.CondM == Inst::C_NEVER)
@@ -181,7 +194,7 @@ void Validator::ProcessItem(state& st)
 					WorkItems.emplace_back(new state(At + 4));
 			}
 			if (At - st.LastBRANCH < 3)
-				Message(st.LastBRANCH, "Two branch instructions within less than 3 instructions.");
+				Message(FailureType::BRANCH_DISTANCE, st.LastBRANCH, "Two branch instructions within less than 3 instructions.");
 			else if (!Instruct.Reg)
 			{	target = Instruct.Rel
 					?	Instruct.Immd.iValue / sizeof(uint64_t) + At + 4
@@ -221,43 +234,43 @@ void Validator::ProcessItem(state& st)
 		// check for RA/RB back to back read/write
 		if ( regRA < 32 && st.LastWreg[0][regRA] == At-1
 			&& (Decode(At-1), IsCondOverlap(GetWrCond(RefInst, regRA, R_A), GetRdCond(Instruct, Inst::X_RA))) )
-			Message(At-1, "Cannot read register ra%d because it just has been written by the previous instruction.", regRA);
+			Message(FailureType::READ_AFTER_WRITE, At-1, "Cannot read register ra%d because it just has been written by the previous instruction.", regRA);
 		if ( regRB < 32 && st.LastWreg[1][regRB] == At-1
 			&& (Decode(At-1), IsCondOverlap(GetWrCond(RefInst, regRB, R_B), GetRdCond(Instruct, Inst::X_RB))) )
-			Message(At-1, "Cannot read register rb%d because it just has been written by the previous instruction.", regRB);
+			Message(FailureType::READ_AFTER_WRITE, At-1, "Cannot read register rb%d because it just has been written by the previous instruction.", regRB);
 		// Two writes to the same register
 		if ( regWA == regWB && regWA != Inst::R_NOP && Inst::isWRegAB(regWA)
 			&& ( Instruct.Sig == Inst::S_BRANCH
 				|| (Instruct.CondA != Inst::C_NEVER && Instruct.CondM != Inst::C_NEVER && Instruct.CondA != (Instruct.CondM ^ 1)) ))
-			Message(At, "Both ALUs write to the same register without inverse condition flags.");
+			Message(FailureType::ALUS_SAME_OUTPUT, At, "Both ALUs write to the same register without inverse condition flags.");
 		if (At < 2 && Instruct.Sig == Inst::S_SBWAIT)
-			Message(At, "The first two fragment shader instructions must not wait for the scoreboard.");
+			Message(FailureType::SHADER_START_SCOREBOARD_WAIT, At, "The first two fragment shader instructions must not wait for the scoreboard.");
 		// unif_addr
 		if (At - st.LastWreg[0][40] <= 2 && (regRA == 32 || regRB == 32))
-			Message(st.LastWreg[0][40], "Must not read uniforms two instructions after write to unif_addr.");
+			Message(FailureType::UNIFORM_AFTER_UNIFORM_ADDRESS, st.LastWreg[0][40], "Must not read uniforms two instructions after write to unif_addr.");
 		if (regWA == 36 || regWB == 36)
 		{	// TMU_NOSWAP
 			for (int i = 56; i <= 63; ++i)
 				if (st.LastWreg[0][i] >= 0)
-				{	Message(st.LastWreg[0][i], "Should not change tmu_noswap after the TMU has been used");
+				{	Message(FailureType::TMU_NOSWAP_AFTER_TMU_USE, st.LastWreg[0][i], "Should not change tmu_noswap after the TMU has been used");
 					break;
 				}
 		}
 		if (At - st.LastWreg[0][36] < 4 && (regWA >= 56 || regWB >= 56))
-			Message(st.LastWreg[0][36], "Write to TMU must be at least 3 instructions after write to tmu_noswap.");
+			Message(FailureType::TMU_AFTER_TMU_NOSWAP, st.LastWreg[0][36], "Write to TMU must be at least 3 instructions after write to tmu_noswap.");
 		// r4
 		int last = max(max(st.LastWreg[0][52], st.LastWreg[0][53]), max(st.LastWreg[0][54], st.LastWreg[0][55]));
 		if (At - last <= 2)
 		{	if (ldr4)
-				Message(last, "Cannot use signal which causes a write to r4 while an SFU instruction is in progress.");
+				Message(FailureType::SIGNAL_R4_WHILE_SFU, last, "Cannot use signal which causes a write to r4 while an SFU instruction is in progress.");
 			if ((regWA & -4) == 52 || (regWB & -4) == 52)
-				Message(last, "SFU is already in use.");
+				Message(FailureType::SFU_IN_USE, last, "SFU is already in use.");
 		}
 		// vector rotations
 		if (CheckVectorRotationLevel && rot >= 0)
 		{	// rot r5
 			if (rot == 0 && st.LastWreg[0][32+5] == At-1)
-				Message(At-1, "Vector rotation by r5 must not follow a write to r5.");
+				Message(FailureType::VECTOR_ROTATION_WRITE_R5, At-1, "Vector rotation by r5 must not follow a write to r5.");
 			CheckRotSrc(st, Instruct.MuxMA);
 			if (Instruct.MuxMA != Instruct.MuxMB)
 				CheckRotSrc(st, Instruct.MuxMB);
@@ -267,11 +280,11 @@ void Validator::ProcessItem(state& st)
 				&& !Inst::isAccu(Instruct.MuxMA) && !Inst::isAccu(Instruct.MuxMB)
 				&& Instruct.MuxAA != Inst::X_RB && Instruct.MuxAB != Inst::X_RB
 				&& Instruct.MuxMA != Inst::X_RB && Instruct.MuxMB != Inst::X_RB )
-				Message(At, "Neither MUL ALU source argument can handle full vector rotation.");
+				Message(FailureType::MEANINGLESS_VECTOR_ROTATION, At, "Neither MUL ALU source argument can handle full vector rotation.");
 		}
 		// TLB Z -> MS_FLAGS
 		if ((regRA == 42 || regRB == 42) && At - st.LastWreg[0][44] <= 2)
-			Message(st.LastWreg[0][44], "Cannot read multisample mask (ms_flags) in the two instructions after TLB Z write.");
+			Message(FailureType::MS_AFTER_TLB_Z, st.LastWreg[0][44], "Cannot read multisample mask (ms_flags) in the two instructions after TLB Z write.");
 		// Combined peripheral access
 		if (( ((0xfff09e0000000000ULL & (1ULL << regWA)) != 0) // TMU, TLB, SFU or Mutex write
 			+ ((0xfff09e0000000000ULL & (1ULL << regWB)) != 0 && !(regWA == regWB && Inst::isWRegAB(regWA)))
@@ -280,22 +293,22 @@ void Validator::ProcessItem(state& st)
 			+ ( (Instruct.Sig >= Inst::S_LOADCV && Instruct.Sig <= Inst::S_LOADAM) // TLB read
 				|| (Instruct.Sig == Inst::S_LDI && (Instruct.LdMode & Inst::L_SEMA)) ) // Semaphore access
 			+ (regWA == 45 || regWA == 46 || regWB == 45 || regWB == 46 || Instruct.Sig == Inst::S_LOADC || Instruct.Sig == Inst::S_LDCEND) ) > 1 ) // combined TLB color read/write
-			Message(At, "More than one access to TMU, TLB, SFU or mutex/semaphore within one instruction.");
+			Message(FailureType::MULTIPLE_ACCESS_PERIPHERY, At, "More than one access to TMU, TLB, SFU or mutex/semaphore within one instruction.");
 		// combined VPM access
 		if (regWA == 49 && regWB == 49)
-			Message(At, "Concurrent write to VPM read and write setup does not work.");
+			Message(FailureType::CONCURRENT_VPM_SETUP, At, "Concurrent write to VPM read and write setup does not work.");
 		else if ((regWA == 49 || regWB == 49) && (regRA == 48 || regRB == 48))
-			Message(At, "Concurrent VPM read with VPM setup does not work.");
+			Message(FailureType::CONCURRENT_VPM_READ, At, "Concurrent VPM read with VPM setup does not work.");
 		if ((regWA == 49 && regWB == 48) || (regWB == 49 && regWA == 48))
-			Message(At, "Concurrent VPM write with VPM setup does not work.");
+			Message(FailureType::CONCURRENT_VPM_WRITE, At, "Concurrent VPM write with VPM setup does not work.");
 		// Some combinations that do not work
 		if (Instruct.Sig != Inst::S_BRANCH)
 		{	if ( !(Instruct.WAddrA == Instruct.WAddrM && (Instruct.CondA ^ Instruct.CondM) == 1) // No problem if both ALUs write conditionally to the same register with opposite conditions.
 				&& ( (Instruct.CondA != Inst::C_AL && Inst::isPeripheralWReg(Instruct.WAddrA))
 					|| (Instruct.CondM != Inst::C_AL && Inst::isPeripheralWReg(Instruct.WAddrM)) ))
-				Message(At, "Conditional write to peripheral register does not work.");
+				Message(FailureType::CONDITIONAL_PERIPHERY, At, "Conditional write to peripheral register does not work.");
 			if (Instruct.PM && (Instruct.Pack & 0xc) == Inst::P_8a && Inst::isPeripheralWReg(Instruct.WAddrM))
-				Message(At, "Pack modes with partial writes do not work for peripheral registers.");
+				Message(FailureType::PACK_PERIPHERY, At, "Pack modes with partial writes do not work for peripheral registers.");
 		}
 		// Update last used fields
 		st.LastRreg[0][regRA] = At;
@@ -313,14 +326,14 @@ void Validator::ProcessItem(state& st)
 		if (st.LastTEND >= 0)
 		{	if ( (((1ULL<<regRA)|(1ULL<<regRB)) & 0x0007000900000000ULL)
 				|| (((1ULL<<regWA)|(1ULL<<regWB)) & 0x0007000000000000ULL) )
-				Message(st.LastTEND, "Must not access uniform, varying or vpm register at thread end.");
+				Message(FailureType::THREAD_END_PERIPHERY, st.LastTEND, "Must not access uniform, varying or vpm register at thread end.");
 			if (regRA == 14 || regRB == 14 || regWA == 14 || regWB == 14)
-				Message(st.LastTEND, "Must not access register 14 of register file A or B at thread end.");
+				Message(FailureType::THREAD_END_R14, st.LastTEND, "Must not access register 14 of register file A or B at thread end.");
 		}
 		if (tend && (regWA < 32 || regWB < 32))
-			Message(At, "The thread end instruction must not write to either register file.");
+			Message(FailureType::THREAD_END_REGISTER, At, "The thread end instruction must not write to either register file.");
 		if (At - st.LastTEND == 2 && (regWA == 44 || regWB == 44))
-			Message(st.LastTEND, "The last program instruction must not write tlbz.");
+			Message(FailureType::THREAD_END_TLB_Z, st.LastTEND, "The last program instruction must not write tlbz.");
 
 		if (tend)
 			TerminateRq(3);


### PR DESCRIPTION
Adds an optional callback to the Validator.
This enables the main-application to be notified of failed validations, instead of them only being printed to stderr.