### PR TITLE
Fixed compilation errors for template deductions

### DIFF
--- a/src/Parser.MSG.h
+++ b/src/Parser.MSG.h
@@ -120,8 +120,8 @@ static const constexpr struct MSG
 	E(MACRO_ARG_EXPECTED              ,180, 0, "Expected macro argument identifier, found '%s'.", const char*);
 	E(MACRO_NO_NESTED_DEFINITION      ,181, 0, "Cannot nest macro definitions. In definition of macro starting at %s (%u).", const char*, uint16_t);
 	W(MACRO_REDEFINED                 ,182, 0, "Redefinition of macro '%s'. Previous definition at %s (%u).", const char*, const char*, uint16_t);
-	E(MACRO_TOO_MANY_ARGS             ,185, 1, "Too many arguments for macro '%s', expected %u.", const char*, unsigned);
-	E(MACRO_TOO_FEW_ARGS              ,185, 2, "Too few arguments for macro '%s', expected %u, found %u.", const char*, unsigned, unsigned);
+	E(MACRO_TOO_MANY_ARGS             ,185, 1, "Too many arguments for macro '%s', expected %u.", const char*, std::size_t);
+	E(MACRO_TOO_FEW_ARGS              ,185, 2, "Too few arguments for macro '%s', expected %u, found %u.", const char*, std::size_t, std::size_t);
 	E(MACRO_HAS_NO_ARGS               ,185, 3, "The macro '%s' does not take arguments.", const char*);
 	F(INTERNAL_MACRO_ARG_EXPANSION    ,189, 0, "Internal error during macro argument expansion, found '%s'.", const char*);
 	// .func
@@ -130,8 +130,8 @@ static const constexpr struct MSG
 	E(FUNCTION_NO_LABEL_DEFINITION    ,191, 0, "Label definition not allowed in functional macro '%s'.", const char*);
 	E(FUNCTION_REQUIRES_ARG_LIST      ,193, 0, "Expected '(' after function name.");
 	E(FUNCTION_EXPECTED_COMMA_OR_BRC  ,194, 0, "Unexpected '%s' in argument list of function '%s'.", const char*, const char*);
-	E(FUNCTION_TOO_MANY_ARGS          ,195, 1, "Too many arguments for function '%s', expected %u.", const char*, unsigned);
-	E(FUNCTION_TOO_FEW_ARGS           ,195, 2, "Too few arguments for function '%s', expected %u, found %u.", const char*, unsigned, unsigned);
+	E(FUNCTION_TOO_MANY_ARGS          ,195, 1, "Too many arguments for function '%s', expected %u.", const char*, std::size_t);
+	E(FUNCTION_TOO_FEW_ARGS           ,195, 2, "Too few arguments for function '%s', expected %u, found %u.", const char*, std::size_t, std::size_t);
 	E(FUNCTION_HAS_NO_ARGS            ,195, 3, "Expected ')' because function '%s' has no arguments.", const char*);
 	E(FUNCTION_INCLOMPLETE_EXPRESSION ,196, 1, "Function '%s' evaluated to an incomplete expression.", const char*);
 	// .include


### PR DESCRIPTION
When trying to compile the current version with the new message-system, I get compilation errors failing to deduce a template argument.


TLDR; The compiler (`gcc version 6.4.1 20170727 (Red Hat 6.4.1-1) (GCC)`) fails to deduce an `unsigned int` template parameter from a `long unsigned int` value.

This PR fixes the error.

Full errors:

    /tmp/vc4asm/src/Parser.cpp: In member function ‘std::vector<exprValue> Parser::parseArgumentList(const string&, size_t)’:
    /tmp/vc4asm/src/Parser.cpp:1497:69: error: no matching function for call to ‘Parser::Fail(const msgTemplate<const char*, unsigned int, unsigned int>&, const char*, size_t&, std::vector<exprValue>::size_type)’
     Fail(MSG.FUNCTION_TOO_FEW_ARGS, name.c_str(), count, args.size());
                                                                     ^
    In file included from /tmp/vc4asm/src/Parser.h:12:0,
                 from /tmp/vc4asm/src/Parser.cpp:10:
    /tmp/vc4asm/src/AssembleInst.h:219:20: note: candidate: template<class ... A> void AssembleInst::Fail(msgTemplate<A ...>, A ...) const
    [[noreturn]] void Fail(const msgTemplate<A...> msg, A... a) const
                    ^~~~
    /tmp/vc4asm/src/AssembleInst.h:219:20: note:   template argument deduction/substitution failed:
    /tmp/vc4asm/src/Parser.cpp:1497:69: note:   inconsistent parameter pack deduction with ‘unsigned int’ and ‘long unsigned int’
     Fail(MSG.FUNCTION_TOO_FEW_ARGS, name.c_str(), count, args.size());
                                                                     ^
    /tmp/vc4asm/src/Parser.cpp:1506:57: error: no matching function for call to ‘Parser::Fail(const msgTemplate<const char*, unsigned int>&, const char*, size_t&)’
     Fail(MSG.FUNCTION_TOO_MANY_ARGS, name.c_str(), count);
                                                         ^
    In file included from /tmp/vc4asm/src/Parser.h:12:0,
                 from /tmp/vc4asm/src/Parser.cpp:10:
    /tmp/vc4asm/src/AssembleInst.h:219:20: note: candidate: template<class ... A> void AssembleInst::Fail(msgTemplate<A ...>, A ...) const
    [[noreturn]] void Fail(const msgTemplate<A...> msg, A... a) const
                    ^~~~
    /tmp/vc4asm/src/AssembleInst.h:219:20: note:   template argument deduction/substitution failed:
    /tmp/vc4asm/src/Parser.cpp:1506:57: note:   inconsistent parameter pack deduction with ‘unsigned int’ and ‘long unsigned int’
     Fail(MSG.FUNCTION_TOO_MANY_ARGS, name.c_str(), count);
                                                         ^
    /tmp/vc4asm/src/Parser.cpp: In member function ‘void Parser::doMACRO(std::unordered_map<std::__cxx11::basic_string<char>, Parser::macro>::const_iterator)’:
    /tmp/vc4asm/src/Parser.cpp:1601:69: error: no matching function for call to ‘Parser::Fail(const msgTemplate<const char*, unsigned int>&, const char*, std::vector<std::__cxx11::basic_string<char> >::size_type)’
      Fail(MSG.MACRO_TOO_MANY_ARGS, m->first.c_str(), argnames.size());
                                                                     ^
    In file included from /tmp/vc4asm/src/Parser.h:12:0,
                 from /tmp/vc4asm/src/Parser.cpp:10:
    /tmp/vc4asm/src/AssembleInst.h:219:20: note: candidate: template<class ... A> void AssembleInst::Fail(msgTemplate<A ...>, A ...) const
    [[noreturn]] void Fail(const msgTemplate<A...> msg, A... a) const
                    ^~~~
    /tmp/vc4asm/src/AssembleInst.h:219:20: note:   template argument deduction/substitution failed:
    /tmp/vc4asm/src/Parser.cpp:1601:69: note:   inconsistent parameter pack deduction with ‘unsigned int’ and ‘long unsigned int’
      Fail(MSG.MACRO_TOO_MANY_ARGS, m->first.c_str(), argnames.size());
                                                                     ^
    /tmp/vc4asm/src/Parser.cpp:1605:81: error: no matching function for call to ‘Parser::Fail(const msgTemplate<const char*, unsigned int, unsigned int>&, const char*, std::vector<std::__cxx11::basic_string<char> >::size_type, std::vector<exprValue>::size_type)’
      Fail(MSG.MACRO_TOO_FEW_ARGS, m->first.c_str(), argnames.size(), args.size());
                                                                                 ^
    In file included from /tmp/vc4asm/src/Parser.h:12:0,
                 from /tmp/vc4asm/src/Parser.cpp:10:
    /tmp/vc4asm/src/AssembleInst.h:219:20: note: candidate: template<class ... A> void AssembleInst::Fail(msgTemplate<A ...>, A ...) const
    [[noreturn]] void Fail(const msgTemplate<A...> msg, A... a) const
                    ^~~~
    /tmp/vc4asm/src/AssembleInst.h:219:20: note:   template argument deduction/substitution failed:
    /tmp/vc4asm/src/Parser.cpp:1605:81: note:   inconsistent parameter pack deduction with ‘unsigned int’ and ‘long unsigned int’
      Fail(MSG.MACRO_TOO_FEW_ARGS, m->first.c_str(), argnames.size(), args.size());