### PR TITLE
Fix incorrect warning for conditional write to IRQ register fixes #37

### DIFF
--- a/src/Inst.h
+++ b/src/Inst.h
@@ -196,7 +196,8 @@ struct Inst
 	/// @remarks There are many more named registers, but none of them have a special meaning in this context.
 	/// See Parser::regMap for a list of all registers.
 	enum reg : uint8_t
-	{	R_NOP = 39
+	{	R_IRQ = 38
+	,	R_NOP = 39
 	};
 	/// ldi variant
 	enum ldmode : uint8_t
@@ -256,6 +257,8 @@ struct Inst
 	static bool isWRegAB(uint8_t reg) { return ((1ULL<<reg) & 0xfff9f9df00000000ULL) != 0; }
 	/// Check whether a register write is a peripheral register.
 	static bool isPeripheralWReg(uint8_t reg) { return (reg^1) > 36 && reg != R_NOP; }
+	/// Check whether a register write is the IRQ register.
+	static bool isIRQWReg(uint8_t reg) { return reg == R_IRQ; }
 
 	/// Simulate a ADD ALU operation of the current instruction.
 	/// @param l Left operand and result

--- a/src/Validator.cpp
+++ b/src/Validator.cpp
@@ -301,7 +301,7 @@ void Validator::ProcessItem(state& st)
 		if (Instruct.Sig != Inst::S_BRANCH)
 		{	if ( !(Instruct.WAddrA == Instruct.WAddrM && (Instruct.CondA ^ Instruct.CondM) == 1) // No problem if both ALUs write conditionally to the same register with opposite conditions.
 				&& ( (Instruct.CondA != Inst::C_AL && Inst::isPeripheralWReg(Instruct.WAddrA) && ! Inst::isIRQWReg(Instruct.WAddrA))
-					|| (Instruct.CondM != Inst::C_AL && Inst::isPeripheralWReg(Instruct.WAddrM) && !Inst::isIRQWReg(Instruct.WAddrA)) ))
+					|| (Instruct.CondM != Inst::C_AL && Inst::isPeripheralWReg(Instruct.WAddrM) && !Inst::isIRQWReg(Instruct.WAddrM)) ))
 				Msg(At, MSG.COND_WR_2_PERIPHERAL);
 			if (Instruct.PM && (Instruct.Pack & 0xc) == Inst::P_8a && Inst::isPeripheralWReg(Instruct.WAddrM))
 				Msg(At, MSG.PARTIAL_WR_2_PERIPHERAL);

--- a/src/Validator.cpp
+++ b/src/Validator.cpp
@@ -300,8 +300,8 @@ void Validator::ProcessItem(state& st)
 		// Some combinations that do not work
 		if (Instruct.Sig != Inst::S_BRANCH)
 		{	if ( !(Instruct.WAddrA == Instruct.WAddrM && (Instruct.CondA ^ Instruct.CondM) == 1) // No problem if both ALUs write conditionally to the same register with opposite conditions.
-				&& ( (Instruct.CondA != Inst::C_AL && Inst::isPeripheralWReg(Instruct.WAddrA))
-					|| (Instruct.CondM != Inst::C_AL && Inst::isPeripheralWReg(Instruct.WAddrM)) ))
+				&& ( (Instruct.CondA != Inst::C_AL && Inst::isPeripheralWReg(Instruct.WAddrA) && ! Inst::isIRQWReg(Instruct.WAddrA))
+					|| (Instruct.CondM != Inst::C_AL && Inst::isPeripheralWReg(Instruct.WAddrM) && !Inst::isIRQWReg(Instruct.WAddrA)) ))
 				Msg(At, MSG.COND_WR_2_PERIPHERAL);
 			if (Instruct.PM && (Instruct.Pack & 0xc) == Inst::P_8a && Inst::isPeripheralWReg(Instruct.WAddrM))
 				Msg(At, MSG.PARTIAL_WR_2_PERIPHERAL);


### PR DESCRIPTION
Doing a conditional write to the IRQ peripheral register causes a "Conditional write to peripheral register does not work" warning. This pull request adds a separate check for the IRQ register to prevent that warning.